### PR TITLE
build: avoid ggml-qnn backend breaking other backend's builds

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -188,7 +188,7 @@ option(GGML_OPENCL                          "ggml: use OpenCL"                  
 option(GGML_OPENCL_PROFILING                "ggml: use OpenCL profiling (increases overhead)" OFF)
 option(GGML_OPENCL_EMBED_KERNELS            "ggml: embed kernels"                             ON)
 option(GGML_OPENCL_USE_ADRENO_KERNELS       "ggml: use optimized kernels for Adreno"          ON)
-option(GGML_QNN                             "ggml: use QNN"                                   ON)
+option(GGML_QNN                             "ggml: use QNN"                                   OFF)
 
 # toolchain for vulkan-shaders-gen
 set   (GGML_VULKAN_SHADERS_GEN_TOOLCHAIN "" CACHE FILEPATH "ggml: toolchain file for vulkan-shaders-gen")

--- a/ggml/src/ggml-qnn/CMakeLists.txt
+++ b/ggml/src/ggml-qnn/CMakeLists.txt
@@ -4,9 +4,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     find_library(LOG_LIB log)
     set(QNN_LINK_LIBRARIES ${LOG_LIB})
     set(QNN_DEFAULT_LIB_SEARCH_PATH "/data/local/tmp/" CACHE STRING "customized library search path for QNN backend")
-else()
-    message(FATAL_ERROR "QNN now only available on Android")
-endif()
 
 if(NOT DEFINED GGML_QNN_SDK_PATH)
     # try read from environment variable
@@ -31,3 +28,7 @@ target_link_libraries(ggml-qnn PRIVATE ${QNN_LINK_LIBRARIES})
 
 string(REGEX REPLACE "/$" "" GGML_QNN_DEFAULT_LIB_SEARCH_PATH "${QNN_DEFAULT_LIB_SEARCH_PATH}")
 target_compile_definitions(ggml-qnn PRIVATE GGML_QNN_DEFAULT_LIB_SEARCH_PATH="${QNN_DEFAULT_LIB_SEARCH_PATH}/")
+
+else()
+    message(FATAL_ERROR "QNN now only available on Android")
+endif()


### PR DESCRIPTION
<!--
 * [x]  I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
 * Self-reported review complexity:
       * [  ] Low
       * [x] Medium
       * [  ] High

### PR Description
ref: original PR https://github.com/ggml-org/llama.cpp/pull/6869

thanks to the huge changes in the software architecture in the latest upstream llama.cpp (especially the maturation of the "backend scheduler" feature), data path of ggml-qnn backend works good as expected with whisper.cpp and llama.cpp.the official command line tool "test-backend-ops" & "llama-cli" has verified on Xiaomi14(Qualcomm Snapdragon 8 Gen3 equipped Android phone).

this implementation **put main logic in one single source file(ggml-qnn.cpp)** because it will **helpful** for other experienced programmers be involved  in dev activity which **similar to** what ggerganov did in [the very beginning of ggml.c](https://github.com/ggml-org/ggml/blob/d406ddb970f68fec6305807f4e8e2535caed1af4/src/ggml.c)/llama.cpp or what Intel did in [the very beginning of ggml-sycl.cpp](https://github.com/ggml-org/ggml/blob/c0052c1a35d6d467345f440c2620faa69d942339/src/ggml-sycl.cpp) or what Qualcomm did in [the ggml-opencl.cpp](https://github.com/ggerganov/llama.cpp/blob/master/ggml/src/ggml-opencl/ggml-opencl.cpp). another main reason of this coding style is I think <b>this will make the developers' workflow more easily</b>: 
- try to overcome all relevant technical issues/difficulties with a specified op GGML_OP_ADD or GGML_OP_MUL_MAT
- then expand other ggml ops accordingly with team-work from AI experts in the upstream llama.cpp community
- the last step is code reconstruction via complex C++ encapsulation for a real project or specified need(this is not mandatory)

this implementation is a concise implementation and focus on the final mission "how to utilize the Hexagon NPU maximally",  hope every domain programmers can understand codes and technical details quickly and it can be considered an open source <b>reference</b> implementation. I think this will be helpful to the llama.cpp community.

## How to setup dev envs on a Linux machine

Ubuntu 20.04,22.04 is validated and recommended, other Linux distributions might be also ok.

the dev activity in this project can be done in pure command line without any IDE, so <b>setup dev envs is simple</b>:

- download and install Qualcomm QNN SDK accordingly from https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk
- utilize our self-made script build-run-android.sh to download Android SDK automatically(pls see below section)

### How to build ggml‐qnn source code for Android and verify ggml-qnn backend on Snapdragon based phone

```
  git clone https://github.com/kantv-ai/ggml-qnn
  cd ggml-qnn
  git checkout kantvai-ggmlqnn
  ./scripts/build-run-android.sh build          (it'll setup local build envs automatically and build the entire project)
  ./scripts/build-run-android.sh updateqnnlib   (upload Qualcomm's QNN binary runtime libs to Android phone)
  ./scripts/build-run-android.sh run_llamacli   (running llama-cli on Android pohone)
  ./scripts/build-run-android.sh run_testop     (running test-backend-ops on Android phone)
```

we can find that this backend works fine as expected from the log output of "adb logcat | grep ggml-qnn". for programmers, we can use "adb logcat | grep ggml-qnn" to help troubleshooting work.
-->